### PR TITLE
Add HTML5 simulation dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Simulation Interface
+
+This project provides a simple HTML5 dashboard that demonstrates a login
+experience and continuously updating status menu. Status messages rotate
+periodically and disappear after 15 seconds.
+
+Open `index.html` in a browser to try it.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Simulation Dashboard</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div id="login" class="card">
+        <h2>Login</h2>
+        <form id="login-form">
+            <label for="username">Username</label>
+            <input type="text" id="username" required>
+            <label for="password">Password</label>
+            <input type="password" id="password" required>
+            <button type="submit">Enter</button>
+        </form>
+    </div>
+
+    <div id="dashboard" class="hidden">
+        <header>
+            <h1>Simulation Dashboard</h1>
+        </header>
+        <section id="status-menu" class="status-menu"></section>
+    </div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,40 @@
+const loginForm = document.getElementById('login-form');
+const loginCard = document.getElementById('login');
+const dashboard = document.getElementById('dashboard');
+const statusMenu = document.getElementById('status-menu');
+
+const messages = [
+    'Checking credentials...',
+    'Connecting to repository...',
+    'Repository sync complete.',
+    'Preparing pull request...',
+    'Pull request created successfully.',
+    'Waiting for CI results...',
+    'Build passed! Ready to merge.'
+];
+let msgIndex = 0;
+
+function addMessage(text) {
+    const div = document.createElement('div');
+    div.className = 'status-item';
+    div.textContent = `${new Date().toLocaleTimeString()} - ${text}`;
+    statusMenu.appendChild(div);
+
+    setTimeout(() => {
+        div.classList.add('fade-out');
+        setTimeout(() => statusMenu.removeChild(div), 1000);
+    }, 15000);
+}
+
+function cycleMessages() {
+    addMessage(messages[msgIndex]);
+    msgIndex = (msgIndex + 1) % messages.length;
+}
+
+loginForm.addEventListener('submit', (e) => {
+    e.preventDefault();
+    loginCard.classList.add('hidden');
+    dashboard.classList.remove('hidden');
+    cycleMessages();
+    setInterval(cycleMessages, 5000);
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,89 @@
+body {
+    font-family: Arial, Helvetica, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4;
+    color: #333;
+}
+
+.card {
+    max-width: 300px;
+    margin: 80px auto;
+    padding: 20px;
+    background: #fff;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    border-radius: 4px;
+}
+
+.card h2 {
+    margin-top: 0;
+    text-align: center;
+}
+
+.card label {
+    display: block;
+    margin-top: 10px;
+}
+
+.card input {
+    width: 100%;
+    padding: 8px;
+    margin-top: 5px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    box-sizing: border-box;
+}
+
+.card button {
+    margin-top: 15px;
+    width: 100%;
+    padding: 10px;
+    background-color: #007acc;
+    color: white;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+}
+
+.card button:hover {
+    background-color: #005f9d;
+}
+
+.hidden {
+    display: none;
+}
+
+header {
+    background-color: #007acc;
+    color: white;
+    padding: 10px;
+    text-align: center;
+}
+
+.status-menu {
+    margin: 20px;
+    padding: 10px;
+    background: white;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    height: 200px;
+    overflow-y: auto;
+}
+
+.status-item {
+    padding: 5px;
+    border-bottom: 1px solid #e8e8e8;
+}
+
+.status-item:last-child {
+    border-bottom: none;
+}
+
+.status-item.fade-out {
+    animation: fadeOut 1s forwards;
+}
+
+@keyframes fadeOut {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}


### PR DESCRIPTION
## Summary
- create a simple login and dashboard interface
- style the dashboard and status menu
- show rotating status messages with fade-out

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6847f88e61f083328c409ca4514dcfa3